### PR TITLE
fix: ImageRepository TagCount Printer Column Type

### DIFF
--- a/api/v1beta1/imagerepository_types.go
+++ b/api/v1beta1/imagerepository_types.go
@@ -151,7 +151,7 @@ func (in ImageRepository) GetTimeout() time.Duration {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Last scan",type=string,JSONPath=`.status.lastScanResult.scanTime`
-// +kubebuilder:printcolumn:name="Tags",type=string,JSONPath=`.status.lastScanResult.tagCount`
+// +kubebuilder:printcolumn:name="Tags",type=integer,JSONPath=`.status.lastScanResult.tagCount`
 
 // ImageRepository is the Schema for the imagerepositories API
 type ImageRepository struct {

--- a/api/v1beta2/imagerepository_types.go
+++ b/api/v1beta2/imagerepository_types.go
@@ -193,7 +193,7 @@ func (in ImageRepository) GetRequeueAfter() time.Duration {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Last scan",type=string,JSONPath=`.status.lastScanResult.scanTime`
-// +kubebuilder:printcolumn:name="Tags",type=string,JSONPath=`.status.lastScanResult.tagCount`
+// +kubebuilder:printcolumn:name="Tags",type=integer,JSONPath=`.status.lastScanResult.tagCount`
 
 // ImageRepository is the Schema for the imagerepositories API
 type ImageRepository struct {


### PR DESCRIPTION
ImageRepository TagCount additional printer column is of type string, while the underlying property is type integer.
This PR makes the additional printer column type integer.